### PR TITLE
MSDK 109 - Correct outdated cell name

### DIFF
--- a/Example/ExampleUITests/Base/UITestBase.swift
+++ b/Example/ExampleUITests/Base/UITestBase.swift
@@ -10,9 +10,7 @@ class UITestBase: XCTestCase {
         continueAfterFailure = false
         app.launch()
         //ToDo - temporary link to payment form
-        // swiftlint:disable line_length
-        XCUIApplication()/*@START_MENU_TOKEN@*/.staticTexts["show drop in view controller (make auth req)"]/*[[".otherElements[\"home\/view\/main\"]",".buttons[\"show drop in view controller (make auth req)\"].staticTexts[\"show drop in view controller (make auth req)\"]",".staticTexts[\"show drop in view controller (make auth req)\"]"],[[[-1,2],[-1,1],[-1,0,1]],[[-1,2],[-1,1]]],[0]]@END_MENU_TOKEN@*/.tap()
-        // swiftlint:enable line_length
+        XCUIApplication().staticTexts["Pay by Card form (no 3DSecure)"].tap()
     }
     
     override func tearDown() {


### PR DESCRIPTION
Tiny fix for UI auto tests (to try out CI/CD process)